### PR TITLE
Fix nextPlayer Turn for Multiple Players

### DIFF
--- a/src/main/java/com/github/robertbraeutigam/tictactoe/Game.java
+++ b/src/main/java/com/github/robertbraeutigam/tictactoe/Game.java
@@ -25,6 +25,6 @@ public final class Game {
    }
 
    private Player nextPlayer() {
-      return players[(turn++) % 2];
+      return players[(turn++) % players.length];
    }
 }


### PR DESCRIPTION
Why:
-  If there are more than 2 players, then they do not get a turn 

How:
- Use players.length rather than the hard-coded value 2.